### PR TITLE
loop git cloning and sync to database after each repository

### DIFF
--- a/convenient-repo/src/lib.rs
+++ b/convenient-repo/src/lib.rs
@@ -173,7 +173,9 @@ impl ConvenientProject {
             if self.git_uri.ends_with('/') {
                 url = url.join(self.git_uri.as_str()).unwrap();
             } else {
-                url = url.join(format!("{}/", self.git_uri).as_str()).unwrap();
+                url = url
+                    .join(format!("{}/{}", self.git_uri, self.name).as_str())
+                    .unwrap();
             }
             info!("New url for {}: {} # {}", self.name, url, self.git_uri);
 


### PR DESCRIPTION
Since the git repositories are essential,
loop until the git repository was able to
be cloned.

Now that the manifest search is in place, the
AOSP manifest repository will create quite
some data. Sync to the database after
processing each git repository.